### PR TITLE
Fix: Use dbcontext factory for migration bundle

### DIFF
--- a/backend/src/Examples/ExampleApp.Examples.Services/DataAccess/ExamplesDbContextFactory.cs
+++ b/backend/src/Examples/ExampleApp.Examples.Services/DataAccess/ExamplesDbContextFactory.cs
@@ -1,0 +1,39 @@
+using LeanCode.AzureIdentity;
+using LeanCode.Npgsql.ActiveDirectory;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Npgsql;
+
+namespace ExampleApp.Examples.Services.DataAccess;
+
+/// <remarks> Used for `dotnet ef migrations bundle`. </remarks>
+public class ExamplesDbContextFactory : IDesignTimeDbContextFactory<ExamplesDbContext>
+{
+    private const string ConnectionStringKey = "PostgreSQL__ConnectionString";
+    private static readonly NpgsqlDataSource DataSource = CreateDataSource();
+
+    private static NpgsqlDataSource CreateDataSource()
+    {
+        var connectionString =
+            Environment.GetEnvironmentVariable(ConnectionStringKey)
+            ?? throw new InvalidOperationException("Failed to find connection string.");
+
+        var dataSourceBuilder = new NpgsqlDataSourceBuilder(connectionString);
+
+        if (dataSourceBuilder.ConnectionStringBuilder.Password is null)
+        {
+            dataSourceBuilder.UseAzureActiveDirectoryAuthentication(DefaultLeanCodeCredential.CreateFromEnvironment());
+        }
+
+        return dataSourceBuilder.Build();
+    }
+
+    public ExamplesDbContext CreateDbContext(string[] args)
+    {
+        var optionsBuilder = new DbContextOptionsBuilder<ExamplesDbContext>();
+
+        optionsBuilder.UseNpgsql(DataSource.CreateConnection());
+
+        return new ExamplesDbContext(optionsBuilder.Options);
+    }
+}

--- a/backend/src/Examples/ExampleApp.Examples.Services/DataAccess/ExamplesDbContextFactory.cs
+++ b/backend/src/Examples/ExampleApp.Examples.Services/DataAccess/ExamplesDbContextFactory.cs
@@ -32,7 +32,7 @@ public class ExamplesDbContextFactory : IDesignTimeDbContextFactory<ExamplesDbCo
     {
         var optionsBuilder = new DbContextOptionsBuilder<ExamplesDbContext>();
 
-        optionsBuilder.UseNpgsql(DataSource.CreateConnection());
+        optionsBuilder.UseNpgsql(DataSource, cfg => cfg.SetPostgresVersion(15, 0));
 
         return new ExamplesDbContext(optionsBuilder.Options);
     }

--- a/backend/src/Examples/ExampleApp.Examples.Services/ExampleApp.Examples.Services.csproj
+++ b/backend/src/Examples/ExampleApp.Examples.Services/ExampleApp.Examples.Services.csproj
@@ -21,6 +21,7 @@
     <!--#if Example -->
     <PackageReference Include="LeanCode.AppRating" />
     <!--#endif -->
+    <PackageReference Include="LeanCode.AzureIdentity" />
     <PackageReference Include="LeanCode.Components" />
     <PackageReference Include="LeanCode.CQRS.Execution" />
     <PackageReference Include="LeanCode.CQRS.MassTransitRelay" />


### PR DESCRIPTION
Previous configuration would require changes in `app_config` terraform common module due to migrations access policy being required in `AddAppConfigurationFromAzureKeyVaultOnNonDevelopmentEnvironment` which was ran by ef previously.