### PR TITLE
Use Services directory for migration bundles

### DIFF
--- a/backend/Jenkinsfile
+++ b/backend/Jenkinsfile
@@ -118,7 +118,7 @@ leancode.builder('exampleapp-backend')
             stage('Build migrations bundle') {
                 dir('src/Examples/ExampleApp.Examples.Services') {
                     sh '''
-                        dotnet ef migrations bundle -o deploy/migrations --force
+                        dotnet ef migrations bundle -o deploy/migrations --force --no-build
                     '''
                 }
             }

--- a/backend/Jenkinsfile
+++ b/backend/Jenkinsfile
@@ -116,11 +116,9 @@ leancode.builder('exampleapp-backend')
             }
 
             stage('Build migrations bundle') {
-                dir('src/Examples/ExampleApp.Examples.Api') {
-                    env.PostgreSQL__ConnectionString = "Host=localhost;Username=postgres;Password=$dbPassword"
-
+                dir('src/Examples/ExampleApp.Examples.Services') {
                     sh '''
-                        dotnet ef migrations bundle -o deploy/migrations --force --no-build --configuration Release
+                        dotnet ef migrations bundle -o deploy/migrations --force
                     '''
                 }
             }

--- a/backend/Tiltfile
+++ b/backend/Tiltfile
@@ -24,7 +24,7 @@ local_resource(
 
 local_resource(
   'build-examples-migrations',
-  ["/bin/bash", "-c", "source dev/config/config.sh && dotnet ef migrations bundle -o dev/out/migrations --project src/Examples/ExampleApp.Examples.Api --force"],
+  'dotnet ef migrations bundle -o dev/out/migrations --project src/Examples/ExampleApp.Examples.Services --force',
   dir='.',
   deps=['src/Examples', 'Directory.Build.props', 'Directory.Packages.props'],
   ignore=['**/obj', '**/bin'],

--- a/backend/release/Dockerfile.migrations
+++ b/backend/release/Dockerfile.migrations
@@ -4,6 +4,6 @@ USER $APP_UID
 
 WORKDIR /home/app
 
-COPY src/Examples/ExampleApp.Examples.Api/deploy/migrations .
+COPY src/Examples/ExampleApp.Examples.Services/deploy/migrations .
 
-ENTRYPOINT ["./migrations"]
+ENTRYPOINT ["./migrations -v"]


### PR DESCRIPTION
Looks like in order for ef to find `IDesignTimeDbContextFactory` bundle needs to be in the same directory otherwise it will fallback to resolving host. Hopefully last fix, keeping the `-v` flag for now in case it fails on CD, will remove it once successful.