### PR TITLE
Fix local migrations bundling

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -17,8 +17,6 @@ cd dev/proxy
 
 ```sh
 cd src/Examples/ExampleApp.Examples.Services
-# This is required for now, but it does not need to point to a real database
-export PostgreSQL__ConnectionString='Host=localhost;Database=app;Username=app;Password=Passw12#'
 dotnet ef migrations add --context ExamplesDbContext --output-dir DataAccess/Migrations InitialMigration # Our context
 ```
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -16,7 +16,7 @@ cd dev/proxy
 ### 2. Generate initial migrations
 
 ```sh
-cd src/Examples/ExampleApp.Examples.Migrations
+cd src/Examples/ExampleApp.Examples.Services
 # This is required for now, but it does not need to point to a real database
 export PostgreSQL__ConnectionString='Host=localhost;Database=app;Username=app;Password=Passw12#'
 dotnet ef migrations add --context ExamplesDbContext -o Migrations InitialMigration # Our context
@@ -41,14 +41,19 @@ Chrome uses a separate certificate store. To add certificate in Chrome:
 
 Related instructions are in the [dev-cluster](../dev-cluster/README.md).
 
-### 5. Migrate the database and start the app
+### 6. Migrate the database and start the app
 
 ```sh
-tilt up migrations api
+tilt up examples-migrations examples-api
 ```
 
 Or run the integration tests:
 
 ```sh
-tilt up integration_tests
+tilt up examples-integration_tests
 ```
+
+> :warning: The migrations bundler is invoked with explicit specification of `linux-x64` as the target architecture.
+> This is to allow bundling on other systems than the container we run the migrations in.
+> Be aware that it still might not be possible to bundle migrations or run them with some combinations
+> of the bundling host and the running target systems.

--- a/backend/README.md
+++ b/backend/README.md
@@ -19,7 +19,7 @@ cd dev/proxy
 cd src/Examples/ExampleApp.Examples.Services
 # This is required for now, but it does not need to point to a real database
 export PostgreSQL__ConnectionString='Host=localhost;Database=app;Username=app;Password=Passw12#'
-dotnet ef migrations add --context ExamplesDbContext -o Migrations InitialMigration # Our context
+dotnet ef migrations add --context ExamplesDbContext --output-dir DataAccess/Migrations InitialMigration # Our context
 ```
 
 ### 3. Trust the certificate (Ubuntu)

--- a/backend/Tiltfile
+++ b/backend/Tiltfile
@@ -24,7 +24,11 @@ local_resource(
 
 local_resource(
   'build-examples-migrations',
-  'dotnet ef migrations bundle -o dev/out/migrations --project src/Examples/ExampleApp.Examples.Services --force',
+  'dotnet ef migrations bundle \
+    --output dev/out/migrations \
+    --project src/Examples/ExampleApp.Examples.Services \
+    --target-runtime linux-x64 \
+    --force',
   dir='.',
   deps=['src/Examples', 'Directory.Build.props', 'Directory.Packages.props'],
   ignore=['**/obj', '**/bin'],


### PR DESCRIPTION
I had problems running containerized migrations bundled on `arch x86_64 GNU/Linux` due to the `libc` versions mismatch and @Saancreed helped me find out where the problem came from and proposed to solve it by forcing the target architecture while bundling.