### PR TITLE
Pin Traefik version in self-signed proxy images

### DIFF
--- a/dev-cluster/apps/Dockerfile.traefik-self-signed
+++ b/dev-cluster/apps/Dockerfile.traefik-self-signed
@@ -1,4 +1,4 @@
-FROM traefik
+FROM traefik:mimolette
 
 COPY --chmod=0644 local.lncd.pl.cert local.lncd.pl.key /certs/
 COPY config.toml /config/config.toml


### PR DESCRIPTION
Our configuration appears to be incompatible with Traefik 3 for now.