### PR TITLE
Fix rabbitmq repository url on dev cluster

### DIFF
--- a/dev-cluster/rabbitmq.tf
+++ b/dev-cluster/rabbitmq.tf
@@ -5,7 +5,7 @@ resource "helm_release" "rabbit" {
   namespace = local.k8s_shared_namespace
 
   chart      = "rabbitmq"
-  repository = "https://charts.bitnami.com/bitnami"
+  repository = "oci://registry-1.docker.io/bitnamicharts"
 
   set {
     name  = "auth.username"


### PR DESCRIPTION
I started getting: https://github.com/bitnami/charts/issues/30582 when tried to redeploy rabbit in develiaebok. Probably related to: https://github.com/helm/helm/issues/13466