### PR TITLE
Change Kratos config so that it requires verified address after registration with OIDC

### DIFF
--- a/infrastructure/kratos.yaml
+++ b/infrastructure/kratos.yaml
@@ -138,7 +138,7 @@ selfservice:
                   parse: false
         oidc:
           hooks:
-            - hook: session
+            - hook: show_verification_ui
             - hook: web_hook
               config:
                 url: "${api}/kratos/sync-identity"


### PR DESCRIPTION
Here, I don't change local config _by design_. Verification on local envs is just painful and does not add anything here.